### PR TITLE
Fix IceTray load+remove without process and a memory leak

### DIFF
--- a/src/filters/pitchshifter.h
+++ b/src/filters/pitchshifter.h
@@ -24,7 +24,7 @@ struct PitchShifter {
 	float *gSynFreq;
 	float *gSynMagn;
 	float sampleRate;
-	PFFFT_Setup *pffftSetup;
+	PFFFT_Setup *pffftSetup = NULL;
 	long gRover = false;
 	double magn, phase, tmp, window, real, imag;
 	double freqPerBin, expct, invOsamp, invFftFrameSize, invFftFrameSize2, invPi;
@@ -64,7 +64,9 @@ struct PitchShifter {
 		gSynMagn = new float[fftFrameSize] {0.f};
 	}
 
-	~PitchShifter() {
+	void cleanup() {
+		if (pffftSetup == NULL)
+			return;
 		pffft_destroy_setup(pffftSetup);
 		delete[] gInFIFO;
 		delete[] gOutFIFO;
@@ -77,6 +79,10 @@ struct PitchShifter {
 		delete[] gSynMagn;
 		pffft_aligned_free(gFFTworksp);
 		pffft_aligned_free(gFFTworkspOut);
+	}
+
+	~PitchShifter() {
+		cleanup();
 	}
 
 	void process(const float pitchShift, const float *input, float *output) {


### PR DESCRIPTION
IceTray was crashing if loaded in Rack/Cardinal as plugin and the host did not call process (audio device stopped or bypassed).
We can solve the issue of memory allocations on audio thread at the same time, by listening to audio sample rate changes and reinitializing the pitch shifter there (this is called after a module is loaded under Rack v2 API)

There was also a leak from the 2 `pShifter` values not being deleted.
